### PR TITLE
[Template] Linter fixer

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -2,17 +2,30 @@ default_stages: [commit, push]
 default_language_version:
   python: python3.8
 repos:
-{% if cookiecutter.use_black == 'y' -%}
-  - repo: https://github.com/psf/black
-    rev: 21.8b0
+  {% if cookiecutter.use_black == 'y' -%}
+  - repo: local
     hooks:
     - id: black
+      name: black
+      entry: black
       exclude: ^(venv/|docs/)
-      types: ['python']
-{% endif %}
-  - repo: https://github.com/PyCQA/flake8
-    rev: 3.8.2
+      language: python
+      types: ['python']{% endif %}
+  - repo: local
+    hooks:
+    - id: autoflake
+      args: ['--in-place','--remove-unused-variables','--remove-all-unused-imports']
+      name: autoflake
+      entry: autoflake
+      language: python
+      exclude: ^(venv/|docs/)
+      types: [python]
+      require_serial: true
+  - repo: local
     hooks:
     - id: flake8
+      name: flake8
+      entry: flake8
       exclude: ^(venv/|docs/)
       types: ['python']
+      language: python

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -2,7 +2,7 @@ bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
-autoflake
+autoflake==1.4
 tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -2,6 +2,7 @@ bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
+autoflake
 tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -7,6 +7,9 @@ python =
     3.7: py37
     3.6: py36
 
+[flake8]
+max-line-length = 88
+
 [testenv:flake8]
 basepython = python
 deps = flake8


### PR DESCRIPTION
- Fixed syntax error in pre-commit config yaml file
- Used local formatter and linter if installed
- Used `autoflake` to auto fix error reported by `flake8`

NOTE: not all errors can be fixed by auto fix